### PR TITLE
The briefings are public now.

### DIFF
--- a/content/log/2026-03-07-trend-detector.mdx
+++ b/content/log/2026-03-07-trend-detector.mdx
@@ -21,7 +21,7 @@ Curious if this is actually useful to you -- the format, the info, any of it.
 
 The briefings have been useful to me privately. I've been busy building [nextjs_boilerplate](https://github.com/modryn-studio/nextjs_boilerplate), [boilerplate](https://github.com/modryn-studio/boilerplate), [modryn-studio-v2](https://github.com/modryn-studio/modryn-studio-v2), and an actual repo that came directly from a briefing signal: [goanyway](https://github.com/modryn-studio/goanyway). The question is whether anyone else finds the briefings useful. The only way to find out is to make them public.
 
-If people find them, read them, and come back, that's the signal I need. I've already started building [Warranted](https://github.com/modryn-studio/warranted) -- go check it out -- but I'm not pushing that yet. The briefings have to prove their value first.
+If people find them, read them, and come back, that's the signal I need before building anything on top of this.
 
 ## What's next
 


### PR DESCRIPTION
Draft log post — fill in narrative before merging.

Covers:
- Public briefings live at modrynstudio.com/tools/trend-detector/briefings/[date]
- Auto-push via GitHub API after each pipeline run
- Trend memory (7-day rolling window, trajectory tracking)
- Reddit validation overhaul (LLM pain queries + raw post excerpts in briefing)
- Pipeline hardening (scorer, clusters, format, gpt-5.4)

Three `<!-- TODO: fill in narrative -->` sections to expand before merging.