### PR TITLE
The five-phase workflow I use to ship indie products

### DIFF
--- a/content/log/2026-03-11-5-phase-build-workflow.mdx
+++ b/content/log/2026-03-11-5-phase-build-workflow.mdx
@@ -3,25 +3,25 @@ title: "The five-phase workflow I use to ship indie products"
 date: "2026-03-11"
 tag: "build"
 seoTitle: "Five-phase indie product workflow: ship live before you build | Build Log"
-description: "I rebuilt my Copilot boilerplate around a five-phase workflow — get live first, track before building, distribute before polishing. Here's what changed and why."
+description: "I rebuilt my Copilot boilerplate around a five-phase workflow: get live first, track before building, distribute before polishing. Here's what changed and why."
 ---
 
 The old workflow had four phases: Foundation, Build, Ship It, Iterate. Distribution came last. Tracking came after shipping. You built the whole thing in the dark, then announced it when it was done. In practice I kept finding I'd built features nobody had seen yet, tracking nothing, with no public footprint until the day I declared it ready.
 
 I reworked the whole thing. Five phases now:
 
-**Phase 1: Foundation** — same as before. Docs, setup, deps. Run `/setup` (renamed from `/init` — VS Code 1.111 ships a built-in `/init` slash command that would shadow it).
+**Phase 1: Foundation.** Same as before. Docs, setup, deps. Run `/setup` (renamed from `/init` because VS Code 1.111 ships a built-in `/init` slash command that would shadow it).
 
-**Phase 2: Go Live** — get a URL, even if the product isn't done. Deploy, register the tool on modrynstudio.com as `status: building`, run the first `/log` post. Every day a URL exists is a day Google can index it.
+**Phase 2: Go Live.** Get a URL, even if the product isn't done. Deploy, register the tool on modrynstudio.com as `status: building`, run the first `/log` post. Every day a URL exists is a day Google can index it.
 
-**Phase 3: Instrument & Distribute** — wire analytics, run `/seo`, run `/launch`, run `@check` as a quality gate, post on socials. All before writing a single line of core product code.
+**Phase 3: Instrument & Distribute.** Wire analytics, run `/seo`, run `/launch`, run `@check` as a quality gate, post on socials. All before writing a single line of core product code.
 
-**Phase 4: Build the Core** — the actual product work. One killer feature, end to end. `/validate` before major implementations. When stuck: competitor research → `/validate` focused → Plan mode → roadmap.
+**Phase 4: Build the Core.** The actual product work. One killer feature, end to end. `/validate` before major implementations. When stuck: competitor research, `/validate` focused, Plan mode, roadmap.
 
-**Phase 5: Iterate** — `@check` → `/tool` update → `/log` post → `/social` if warranted. Repeat until first paying user.
+**Phase 5: Iterate.** `@check`, `/tool` update, `/log` post, `/social` if warranted. Repeat until first paying user.
 
-The biggest shift: distribution isn't the end state. It's a habit you build from day one. Waiting until you have something "worth sharing" means you're building in the dark — no data, no feedback, nothing compounding while you work.
+The biggest shift: distribution isn't the end state. It's a habit you build from day one. Waiting until you have something "worth sharing" means you're building in the dark: no data, no feedback, nothing compounding while you work.
 
-`@check` got promoted too. It's not a one-time pre-ship gate — it runs at transition points: end of Phase 3 (setup clean before building features?) and after every major Phase 4 implementation (ready for users?). Before running it, switch the chat permissions picker to **Bypass Approvals** so it can run end-to-end without interrupting itself on every file edit.
+`@check` got promoted too. It's not a one-time pre-ship gate. It runs at transition points: end of Phase 3 (setup clean before building features?) and after every major Phase 4 implementation (ready for users?). Before running it, switch the chat permissions picker to **Bypass Approvals** so it can run end-to-end without interrupting itself on every file edit.
 
 The boilerplate is at [github.com/modryn-studio/nextjs_boilerplate](https://github.com/modryn-studio/nextjs_boilerplate). Public, free to copy. Built for one-person studios that ship fast.


### PR DESCRIPTION
Draft log post — fill in narrative before merging.

Three `<!-- TODO -->` sections to complete:

1. **After the opening** — what triggered the rethink? Was there a specific moment during songfor.me where the old four-phase order hurt you? One sentence is enough.
2. **After the phase list** — what surprised you about validating this order against Pieter Levels and Marc Lou? Did it confirm your instincts or push back anywhere? One honest paragraph.
3. **Near the end** — anything else worth calling out? The `/validate` two-modes distinction? The when-stuck playbook? The `#debugEventsSnapshot` tip? Pick one, add a sentence or two.

**Related:** this post is a direct follow-up to [2026-02-26-how-i-set-up-my-copilot-workflow](https://github.com/modryn-studio/modryn-studio-v2/blob/main/content/log/2026-02-26-how-i-set-up-my-copilot-workflow.mdx). That post references `/init` — which is now `/setup` in the boilerplate. No edit needed to the old post (it's historical), but worth noting in the new one that the rename happened.

**No tool JSON to update** — there's no `nextjs-boilerplate.json` in `content/tools/`, so the tool card step is skipped.